### PR TITLE
Remove duplicate limits policy file

### DIFF
--- a/policies/limits.yml
+++ b/policies/limits.yml
@@ -1,8 +1,0 @@
-rate_limits:
-  burst: 100
-  sustained_per_minute: 600
-payload_limits:
-  max_bytes: 1048576
-  metadata_max_bytes: 16384
-streaming:
-  max_concurrent_streams: 16


### PR DESCRIPTION
## Summary
- remove the duplicate `policies/limits.yml` policy file so that only `policies/limits.yaml` remains

## Testing
- test ! -f policies/limits.yml && echo "OK: limits.yml entfernt"

------
https://chatgpt.com/codex/tasks/task_e_68e0a7b00508832cbce1b793b0182ce0