### PR TITLE
Ensure API crate declares serde_yaml dependency

### DIFF
--- a/apps/api/Cargo.toml
+++ b/apps/api/Cargo.toml
@@ -13,6 +13,7 @@ dotenvy = "0.15"
 prometheus = "0.13"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio", "postgres"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower = "0.5"


### PR DESCRIPTION
## Summary
- add the missing `serde_yaml` dependency to the API crate so builds succeed when the config module uses YAML parsing

## Testing
- `cargo check --manifest-path apps/api/Cargo.toml` *(fails: unable to reach crates.io due to 403 CONNECT tunnel error in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e19de471f8832cbca69a394efcc4bc