### PR TITLE
Fix deny config unmaintained level

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,6 @@
 [advisories]
 vulnerability = "deny"
-unmaintained = "warn"
+unmaintained = "deny"
 yanked = "warn"
 notice = "warn"
 ignore = []


### PR DESCRIPTION
## Summary
- set the advisories.unmaintained level in deny.toml to "deny" so cargo-deny can parse the configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2054ecc24832c8c8d1fe80b2973cf