### PR TITLE
Fix SBOM workflow to use maintained Anchore action

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: anchore/syft-action@v0.16.0
+      - uses: anchore/sbom-action@v0.15.7
         with:
-          output: sbom.spdx.json
+          output-file: sbom.spdx.json
       - uses: actions/upload-artifact@v4
         with:
           name: sbom


### PR DESCRIPTION
## Summary
- replace the deprecated anchore/syft-action with anchore/sbom-action@v0.15.7 in the security workflow
- update the output parameter name to align with the maintained sbom-action inputs

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e205549218832c923f58a0f559aa61