### PR TITLE
Remove deprecated unmaintained advisory setting

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,5 @@
 [advisories]
 vulnerability = "deny"
-unmaintained = "warn"
 yanked = "warn"
 notice = "warn"
 ignore = []


### PR DESCRIPTION
## Summary
- remove the deprecated `unmaintained` advisory setting from `deny.toml`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2087c62b0832caaf041ed394cc787