### PR TITLE
Fix workflow YAML syntax and artifact naming

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -50,15 +50,13 @@ jobs:
         working-directory: apps/api
       - run: cargo test --all-features --verbose
         working-directory: apps/api
-  dependency-audit:
-    name: dependency audit
-    runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || (
-      github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'security')
-    )
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: EmbarkStudios/cargo-deny-action@v1
-        with:
-          arguments: check
+    dependency-audit:
+      name: dependency audit
+      runs-on: ubuntu-latest
+      if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'security'))
+      steps:
+        - uses: actions/checkout@v4
+        - uses: dtolnay/rust-toolchain@stable
+        - uses: EmbarkStudios/cargo-deny-action@v1
+          with:
+            arguments: check

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,5 +21,5 @@ jobs:
           output-file: sbom.spdx.json
       - uses: actions/upload-artifact@v4
         with:
-          name: weltgewebe-sbom-spdx
+          name: weltgewebe-sbom-spdx-json
           path: sbom.spdx.json

--- a/.github/workflows/semantics-intake.yml
+++ b/.github/workflows/semantics-intake.yml
@@ -20,39 +20,39 @@ jobs:
       - name: Enforce size limits
         run: |
           python - <<'PY'
-import math
-import sys
-from pathlib import Path
+            import math
+            import sys
+            from pathlib import Path
 
-import yaml
+            import yaml
 
-limits_path = Path("policies/limits.yaml")
-if not limits_path.exists():
-    print("::error::policies/limits.yaml missing")
-    sys.exit(1)
+            limits_path = Path("policies/limits.yaml")
+            if not limits_path.exists():
+                print("::error::policies/limits.yaml missing")
+                sys.exit(1)
 
-data = yaml.safe_load(limits_path.read_text(encoding="utf-8")) or {}
-sem = data.get("semantics", {})
-try:
-    max_nodes = int(sem.get("max_nodes_jsonl_mb"))
-    max_edges = int(sem.get("max_edges_jsonl_mb"))
-except (TypeError, ValueError):
-    print("::error::semantics limits must be integers")
-    sys.exit(1)
+            data = yaml.safe_load(limits_path.read_text(encoding="utf-8")) or {}
+            sem = data.get("semantics", {})
+            try:
+                max_nodes = int(sem.get("max_nodes_jsonl_mb"))
+                max_edges = int(sem.get("max_edges_jsonl_mb"))
+            except (TypeError, ValueError):
+                print("::error::semantics limits must be integers")
+                sys.exit(1)
 
-def file_size_mb(path: Path) -> int:
-    return math.ceil(path.stat().st_size / (1024 * 1024))
+            def file_size_mb(path: Path) -> int:
+                return math.ceil(path.stat().st_size / (1024 * 1024))
 
-for path in Path(".gewebe/in").glob("*.jsonl"):
-    size_mb = file_size_mb(path)
-    if path.name.endswith(".nodes.jsonl") and size_mb > max_nodes:
-        print(f"::error::{path} > limit ({size_mb} MB > {max_nodes} MB)")
-        sys.exit(1)
-    if path.name.endswith(".edges.jsonl") and size_mb > max_edges:
-        print(f"::error::{path} > limit ({size_mb} MB > {max_edges} MB)")
-        sys.exit(1)
-print("Semantic intake size limits respected")
-PY
+            for path in Path(".gewebe/in").glob("*.jsonl"):
+                size_mb = file_size_mb(path)
+                if path.name.endswith(".nodes.jsonl") and size_mb > max_nodes:
+                    print(f"::error::{path} > limit ({size_mb} MB > {max_nodes} MB)")
+                    sys.exit(1)
+                if path.name.endswith(".edges.jsonl") and size_mb > max_edges:
+                    print(f"::error::{path} > limit ({size_mb} MB > {max_edges} MB)")
+                    sys.exit(1)
+            print("Semantic intake size limits respected")
+            PY
       - name: Validate incoming JSONL (if present)
         run: |
           set -euo pipefail

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -43,24 +43,25 @@ jobs:
       - name: Validate minimal schema keys
         run: |
           python - <<'PY'
-import sys, yaml, pathlib
-p = pathlib.Path(".wgx/profile.yml")
-data = yaml.safe_load(p.read_text(encoding="utf-8"))
-required_top = ["version","env_priority","tooling","tasks"]
-missing = [k for k in required_top if k not in data]
-if missing:
-    print(f"::error::missing keys: {missing}")
-    sys.exit(1)
-envp = data["env_priority"]
-if not isinstance(envp, list) or not envp:
-    print("::error::env_priority must be a non-empty list")
-    sys.exit(1)
-for t in ["up","lint","test","build","smoke"]:
-    if t not in data["tasks"]:
-        print(f"::error::task '{t}' missing")
-        sys.exit(1)
-print("wgx profile OK")
-PY
+            import sys, yaml, pathlib
+
+            p = pathlib.Path(".wgx/profile.yml")
+            data = yaml.safe_load(p.read_text(encoding="utf-8"))
+            required_top = ["version", "env_priority", "tooling", "tasks"]
+            missing = [k for k in required_top if k not in data]
+            if missing:
+                print(f"::error::missing keys: {missing}")
+                sys.exit(1)
+            envp = data["env_priority"]
+            if not isinstance(envp, list) or not envp:
+                print("::error::env_priority must be a non-empty list")
+                sys.exit(1)
+            for t in ["up", "lint", "test", "build", "smoke"]:
+                if t not in data["tasks"]:
+                    print(f"::error::task '{t}' missing")
+                    sys.exit(1)
+            print("wgx profile OK")
+            PY
 
       - name: (Optional) UV bootstrap (pyproject present)
         if: ${{ hashFiles('**/pyproject.toml') != '' }}


### PR DESCRIPTION
## Summary
- fix the dependency audit job syntax in the API workflow
- correct indentation for inline scripts in semantics-intake and wgx-guard workflows
- rename the SBOM artifact to comply with GitHub's naming rules

## Testing
- not run (YAML change only)


------
https://chatgpt.com/codex/tasks/task_e_68e20ce04ec0832c804c4864a7fbfc68