### PR TITLE
Fix wgx guard validation script

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -41,27 +41,7 @@ jobs:
       - name: Install PyYAML
         run: python -m pip install pyyaml
       - name: Validate minimal schema keys
-        run: |
-          python - <<'PY'
-            import sys, yaml, pathlib
-
-            p = pathlib.Path(".wgx/profile.yml")
-            data = yaml.safe_load(p.read_text(encoding="utf-8"))
-            required_top = ["version", "env_priority", "tooling", "tasks"]
-            missing = [k for k in required_top if k not in data]
-            if missing:
-                print(f"::error::missing keys: {missing}")
-                sys.exit(1)
-            envp = data["env_priority"]
-            if not isinstance(envp, list) or not envp:
-                print("::error::env_priority must be a non-empty list")
-                sys.exit(1)
-            for t in ["up", "lint", "test", "build", "smoke"]:
-                if t not in data["tasks"]:
-                    print(f"::error::task '{t}' missing")
-                    sys.exit(1)
-            print("wgx profile OK")
-            PY
+        run: python ci/scripts/validate_wgx_profile.py
 
       - name: (Optional) UV bootstrap (pyproject present)
         if: ${{ hashFiles('**/pyproject.toml') != '' }}

--- a/ci/scripts/validate_wgx_profile.py
+++ b/ci/scripts/validate_wgx_profile.py
@@ -1,0 +1,66 @@
+"""Validate the minimal schema for .wgx/profile.yml."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import Sequence
+
+import yaml
+
+
+def _error(message: str) -> None:
+    print(f"::error::{message}")
+
+
+def _require_keys(data: dict[str, object], keys: Sequence[str]) -> bool:
+    missing = [key for key in keys if key not in data]
+    if missing:
+        _error(f"missing keys: {missing}")
+        return False
+    return True
+
+
+def main() -> int:
+    profile_path = pathlib.Path(".wgx/profile.yml")
+    try:
+        contents = profile_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        _error(".wgx/profile.yml missing")
+        return 1
+
+    try:
+        data = yaml.safe_load(contents)
+    except yaml.YAMLError as exc:  # pragma: no cover - best effort logging
+        _error(f"failed to parse YAML: {exc}")
+        return 1
+
+    if not isinstance(data, dict):
+        _error("profile must be a mapping")
+        return 1
+
+    top_level_required = ["version", "env_priority", "tooling", "tasks"]
+    if not _require_keys(data, top_level_required):
+        return 1
+
+    env_priority = data.get("env_priority")
+    if not isinstance(env_priority, list) or not env_priority:
+        _error("env_priority must be a non-empty list")
+        return 1
+
+    tasks = data.get("tasks")
+    if not isinstance(tasks, dict):
+        _error("tasks must be a mapping")
+        return 1
+
+    for task_name in ["up", "lint", "test", "build", "smoke"]:
+        if task_name not in tasks:
+            _error(f"task '{task_name}' missing")
+            return 1
+
+    print("wgx profile OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- replace the inline Python heredoc in wgx-guard with a direct invocation of a helper script
- add ci/scripts/validate_wgx_profile.py to validate the minimal .wgx/profile.yml schema and improve diagnostics

## Testing
- `python ci/scripts/validate_wgx_profile.py` *(fails locally: missing PyYAML because the package index cannot be reached from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e21080076c832c8ee6148025ad7994