### PR TITLE
Handle nested pyproject files in wgx guard

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -66,10 +66,20 @@ jobs:
       - name: (Optional) UV bootstrap (pyproject present)
         if: ${{ hashFiles('**/pyproject.toml') != '' }}
         run: |
+          set -euo pipefail
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           uv --version
-          uv sync --frozen
+          while IFS= read -r -d '' file; do
+            dir="$(dirname "$file")"
+            echo "::group::uv sync in $dir"
+            if [ -f "$dir/uv.lock" ]; then
+              (cd "$dir" && uv sync --frozen)
+            else
+              (cd "$dir" && uv sync)
+            fi
+            echo "::endgroup::"
+          done < <(find . -name "pyproject.toml" -print0)
 
       - name: Done
         run: echo "wgx-guard passed ✅"


### PR DESCRIPTION
## Summary
- adjust the wgx guard workflow to bootstrap uv within each directory containing a pyproject
- ensure directories with a uv.lock use frozen sync while others fall back to a regular uv sync

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2116a55cc832ca186425c771f1e08