### PR TITLE
Allow overriding policy limits path via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Beim lokalen Build ohne CI-Kontext setzen wir sie automatisch auf `"unknown"`,
 während die Pipelines im CI die echten Werte einspeisen. Es besteht daher kein
 Bedarf, `.env.example` um diese Variablen zu erweitern.
 
+### Policies-Pfad (Override)
+
+Standardmäßig sucht die API die Datei `policies/limits.yaml`. Für abweichende Layouts
+kannst du den Pfad via `POLICY_LIMITS_PATH=/pfad/zur/limits.yaml` setzen.
+
 ### Konfigurations-Overrides (HA_*)
 
 Die API liest Standardwerte aus `configs/app.defaults.yml`. Für Deployments können


### PR DESCRIPTION
## Summary
- prefer an explicit POLICY_LIMITS_PATH override before falling back to existing policy file locations
- document the POLICY_LIMITS_PATH option alongside other configuration notes

## Testing
- cargo fmt -- apps/api/src/routes/health.rs

------
https://chatgpt.com/codex/tasks/task_e_68e21274785c832cad65a5e53b36d790