### PR TITLE
Make uv sync loop resilient to per-project failures

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -62,7 +62,7 @@ jobs:
             echo "::group::uv sync in $dir"
             rc=0
             if [ -f "$dir/uv.lock" ]; then
-              # innerhalb eines Subshells 'set +e' erlauben, um weiterzumachen
+              # allow 'set +e' within a subshell to continue on error
               ( set +e; cd "$dir" && uv sync --frozen ); rc=$?
             else
               ( set +e; cd "$dir" && uv sync ); rc=$?

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -46,20 +46,37 @@ jobs:
       - name: (Optional) UV bootstrap (pyproject present)
         if: ${{ hashFiles('**/pyproject.toml') != '' }}
         run: |
-          set -euo pipefail
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           uv --version
+          uv sync --frozen
+
+      - name: Sync nested Python projects (non-fatal per dir, fail at end if any)
+        if: ${{ hashFiles('**/pyproject.toml') != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          failures=0
           while IFS= read -r -d '' file; do
             dir="$(dirname "$file")"
             echo "::group::uv sync in $dir"
+            rc=0
             if [ -f "$dir/uv.lock" ]; then
-              (cd "$dir" && uv sync --frozen)
+              # innerhalb eines Subshells 'set +e' erlauben, um weiterzumachen
+              ( set +e; cd "$dir" && uv sync --frozen ); rc=$?
             else
-              (cd "$dir" && uv sync)
+              ( set +e; cd "$dir" && uv sync ); rc=$?
+            fi
+            if [ $rc -ne 0 ]; then
+              echo "::error::uv sync failed in $dir (exit $rc)"
+              failures=$((failures+1))
             fi
             echo "::endgroup::"
           done < <(find . -name "pyproject.toml" -print0)
+          if [ "$failures" -gt 0 ]; then
+            echo "::error::$failures Python workspace(s) failed to sync"
+            exit 1
+          fi
 
       - name: Done
         run: echo "wgx-guard passed ✅"

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -49,7 +49,7 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           uv --version
-          uv sync --frozen
+          if [ -f uv.lock ]; then uv sync --frozen; else uv sync; fi
 
       - name: Sync nested Python projects (non-fatal per dir, fail at end if any)
         if: ${{ hashFiles('**/pyproject.toml') != '' }}


### PR DESCRIPTION
## Summary
- install uv once in the bootstrap step and keep the nested syncs separate
- iterate over every pyproject.toml with a null-delimited find loop
- track per-directory uv sync failures and report them collectively at the end

## Testing
- no tests were run (not needed for this change)

------
https://chatgpt.com/codex/tasks/task_e_68e212a4eebc832ca9abdabb1ef56476