### PR TITLE
Improve wgx profile validator robustness

### DIFF
--- a/ci/scripts/validate_wgx_profile.py
+++ b/ci/scripts/validate_wgx_profile.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import importlib
+import importlib.util
 import pathlib
 import sys
+from types import ModuleType
 from typing import Sequence
-
-import yaml
 
 
 def _error(message: str) -> None:
@@ -21,7 +22,26 @@ def _require_keys(data: dict[str, object], keys: Sequence[str]) -> bool:
     return True
 
 
+def _load_yaml_module() -> ModuleType | None:
+    existing = sys.modules.get("yaml")
+    if isinstance(existing, ModuleType):
+        return existing
+
+    module = importlib.util.find_spec("yaml")
+    if module is None:
+        _error(
+            "PyYAML not installed. Install it with 'python -m pip install pyyaml' before running this script."
+        )
+        return None
+
+    return importlib.import_module("yaml")
+
+
 def main() -> int:
+    yaml = _load_yaml_module()
+    if yaml is None:
+        return 1
+
     profile_path = pathlib.Path(".wgx/profile.yml")
     try:
         contents = profile_path.read_text(encoding="utf-8")

--- a/ci/scripts/validate_wgx_profile.py
+++ b/ci/scripts/validate_wgx_profile.py
@@ -33,7 +33,7 @@ def _missing_keys(data: dict[str, object], keys: Iterable[str]) -> list[str]:
 
 def _load_yaml_module() -> ModuleType | None:
     existing = sys.modules.get("yaml")
-    if isinstance(existing, ModuleType):
+    if isinstance(existing, ModuleType) and hasattr(existing, "safe_load"):
         return existing
 
     module = importlib.util.find_spec("yaml")


### PR DESCRIPTION
## Summary
- add a helper that locates the PyYAML module before loading profiles
- emit a clear ::error:: message when PyYAML is missing instead of crashing with ModuleNotFoundError
- reuse the helper to keep the remainder of the validation logic unchanged

## Testing
- python ci/scripts/validate_wgx_profile.py
- python - <<'PY'
import sys
import types

module = types.ModuleType("yaml")

def fake_safe_load(text):
    return {
        "version": 1,
        "env_priority": ["a"],
        "tooling": {},
        "tasks": {name: {} for name in ["up", "lint", "test", "build", "smoke"]},
    }

module.safe_load = fake_safe_load
module.__spec__ = types.SimpleNamespace()

sys.modules["yaml"] = module

import ci.scripts.validate_wgx_profile as module

exit_code = module.main()
print(f"exit_code={exit_code}")
PY
- python - <<'PY'
import sys
import types

module = types.ModuleType("yaml")

def fake_safe_load(text):
    return {"version": 1, "env_priority": [], "tooling": {}, "tasks": {}}

module.safe_load = fake_safe_load
module.__spec__ = types.SimpleNamespace()

sys.modules["yaml"] = module

import ci.scripts.validate_wgx_profile as module

exit_code = module.main()
print(f"exit_code={exit_code}")
PY

------
https://chatgpt.com/codex/tasks/task_e_68e212f1db9c832cbad8189dcae8f5cd