### PR TITLE
Fix cargo-deny advisory configuration

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,7 @@
 vulnerability = "deny"
 yanked = "warn"
 notice = "warn"
-unmaintained = "warn"
+unsound = "warn"
 ignore = []
 
 [bans]


### PR DESCRIPTION
## Summary
- replace the deprecated `unmaintained` advisory warning with the supported `unsound` option

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e214f26d30832cbc0fbc5204d7a97b