### PR TITLE
Use env::var_os for policy limits path

### DIFF
--- a/apps/api/src/routes/health.rs
+++ b/apps/api/src/routes/health.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, path::Path};
+use std::{env, fs, path::{Path, PathBuf}};
 
 use axum::{
     extract::State,
@@ -66,10 +66,7 @@ async fn ready(State(state): State<ApiState>) -> Response {
 
     // Prefer an explicit configuration via env var to avoid hard-coded path assumptions.
     // Fallbacks stay for dev/CI convenience.
-    let env_path = env::var("POLICY_LIMITS_PATH")
-        .ok()
-        .map(Path::new)
-        .map(Path::to_path_buf);
+    let env_path = env::var_os("POLICY_LIMITS_PATH").map(PathBuf::from);
     let fallback_paths = [
         Path::new("policies/limits.yaml").to_path_buf(),
         Path::new(env!("CARGO_MANIFEST_DIR")).join("../policies/limits.yaml"),


### PR DESCRIPTION
## Summary
- handle `POLICY_LIMITS_PATH` using `env::var_os` so non-UTF-8 paths are supported
- convert the environment override to a `PathBuf` and evaluate it before fallback paths

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e215d99b78832cac1106dc2f4db744