### PR TITLE
Handle dotenv loading failures more gracefully

### DIFF
--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -25,9 +25,9 @@ async fn main() -> anyhow::Result<()> {
     }
 
     if let Err(error) = dotenv {
-        if !matches!(&error, dotenvy::Error::Io(io_error) if io_error.kind() == ErrorKind::NotFound)
-        {
-            tracing::warn!(%error, "failed to load environment from .env file");
+        match &error {
+            dotenvy::Error::Io(io_error) if io_error.kind() == ErrorKind::NotFound => {},
+            _ => tracing::warn!(%error, "failed to load environment from .env file"),
         }
     }
     init_tracing()?;

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -20,8 +20,8 @@ use tracing_subscriber::{fmt, EnvFilter};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let dotenv = dotenvy::dotenv();
-    if let Some(path) = dotenv.as_ref().ok().map(|path| path.as_path()) {
-        tracing::debug!("loaded environment variables from {path:?}");
+    if let Ok(path) = &dotenv {
+        tracing::debug!(?path, "loaded environment variables from .env file");
     }
 
     if let Err(error) = dotenv {


### PR DESCRIPTION
## Summary
- update the API bootstrap to capture the result of `dotenvy::dotenv()` without using `ok().as_deref()`
- log successful `.env` loads and warn when an unexpected error occurs while still ignoring missing files

## Testing
- cargo check -p weltgewebe-api

------
https://chatgpt.com/codex/tasks/task_e_68e21472326c832c9eec627be08dee8a