### PR TITLE
Improve UV bootstrap robustness in wgx guard workflow

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -65,6 +65,8 @@ jobs:
                 || { echo "::error::uv sync failed in $dir"; status=1; }
             fi
             echo "::endgroup::"
+          # Use '-type f' to ensure only files named 'pyproject.toml' are processed, not directories.
+          # This improves specificity and avoids issues if a directory is named 'pyproject.toml' (unlikely).
           done < <(find . -type f -name "pyproject.toml" -print0)
 
           exit "$status"

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -58,8 +58,8 @@ jobs:
             dir="$(dirname "$file")"
             echo "::group::uv sync in $dir"
             if [ -f "$dir/uv.lock" ]; then
-              ( cd "$dir" && "$UV" sync --locked ) \
-                || { echo "::error::uv sync failed in $dir (locked)"; status=1; }
+              ( cd "$dir" && "$UV" sync --frozen ) \
+                || { echo "::error::uv sync failed in $dir (frozen)"; status=1; }
             else
               ( cd "$dir" && "$UV" sync ) \
                 || { echo "::error::uv sync failed in $dir"; status=1; }

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -45,38 +45,29 @@ jobs:
 
       - name: (Optional) UV bootstrap (pyproject present)
         if: ${{ hashFiles('**/pyproject.toml') != '' }}
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-          uv --version
-          if [ -f uv.lock ]; then uv sync --frozen; else uv sync; fi
-
-      - name: Sync nested Python projects (non-fatal per dir, fail at end if any)
-        if: ${{ hashFiles('**/pyproject.toml') != '' }}
         shell: bash
         run: |
           set -euo pipefail
-          failures=0
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          UV="$HOME/.local/bin/uv"
+          "$UV" --version
+
+          status=0
           while IFS= read -r -d '' file; do
             dir="$(dirname "$file")"
             echo "::group::uv sync in $dir"
-            rc=0
             if [ -f "$dir/uv.lock" ]; then
-              # allow 'set +e' within a subshell to continue on error
-              ( set +e; cd "$dir" && uv sync --frozen ); rc=$?
+              ( cd "$dir" && "$UV" sync --locked ) \
+                || { echo "::error::uv sync failed in $dir (locked)"; status=1; }
             else
-              ( set +e; cd "$dir" && uv sync ); rc=$?
-            fi
-            if [ $rc -ne 0 ]; then
-              echo "::error::uv sync failed in $dir (exit $rc)"
-              failures=$((failures+1))
+              ( cd "$dir" && "$UV" sync ) \
+                || { echo "::error::uv sync failed in $dir"; status=1; }
             fi
             echo "::endgroup::"
-          done < <(find . -name "pyproject.toml" -print0)
-          if [ "$failures" -gt 0 ]; then
-            echo "::error::$failures Python workspace(s) failed to sync"
-            exit 1
-          fi
+          done < <(find . -type f -name "pyproject.toml" -print0)
+
+          exit "$status"
 
       - name: Done
         run: echo "wgx-guard passed ✅"


### PR DESCRIPTION
## Summary
- install uv once and reuse its path for syncing Python projects
- sync each pyproject directory individually, using --locked only when uv.lock exists
- continue through all projects while capturing failures and reporting them at the end

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2162aa7b4832cb7468cee6cbe996d