### PR TITLE
Adjust mapping type hints in wgx profile validator

### DIFF
--- a/ci/scripts/validate_wgx_profile.py
+++ b/ci/scripts/validate_wgx_profile.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# -*- coding: utf-8 -*-
+
 """Validate the minimal schema for ``.wgx/profile.yml``.
 
 The wgx-guard workflow embeds this script and previously relied on an inline
@@ -14,7 +17,7 @@ import importlib.util
 import pathlib
 import sys
 from types import ModuleType
-from typing import Sequence
+from collections.abc import Iterable, Mapping
 
 
 REQUIRED_TOP_LEVEL_KEYS = ("version", "env_priority", "tooling", "tasks")
@@ -27,7 +30,7 @@ def _error(message: str) -> None:
     print(f"::error::{message}")
 
 
-def _missing_keys(data: dict[str, object], keys: Iterable[str]) -> list[str]:
+def _missing_keys(data: Mapping[str, object], keys: Iterable[str]) -> list[str]:
     return [key for key in keys if key not in data]
 
 


### PR DESCRIPTION
## Summary
- add SPDX license identifier and encoding declaration to the validator script
- import Iterable and Mapping from collections.abc and widen the helper signature to accept mappings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2172f3edc832cb57ac5cc794656e5