### PR TITLE
chore(api): format sources

### DIFF
--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
 
     if let Err(error) = dotenv {
         match &error {
-            dotenvy::Error::Io(io_error) if io_error.kind() == ErrorKind::NotFound => {},
+            dotenvy::Error::Io(io_error) if io_error.kind() == ErrorKind::NotFound => {}
             _ => tracing::warn!(%error, "failed to load environment from .env file"),
         }
     }

--- a/apps/api/src/routes/health.rs
+++ b/apps/api/src/routes/health.rs
@@ -1,4 +1,7 @@
-use std::{env, fs, path::{Path, PathBuf}};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
 
 use axum::{
     extract::State,


### PR DESCRIPTION
## Summary
- run `cargo fmt` to bring the API sources back in line with rustfmt defaults

## Testing
- cargo clippy -- -D warnings
- cargo test --locked
- npm ci
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e217a8343c832c918be9a1acae6c97