### PR TITLE
Fix licenses default policy in deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,7 @@ multiple-versions = "warn"
 wildcards = "deny"
 
 [licenses]
+default = "deny"
 unlicensed = "deny"
 allow = [
   "Apache-2.0",
@@ -17,9 +18,8 @@ allow = [
   "BSD-3-Clause",
   "ISC",
   "MIT",
-  "Zlib",
+  "Zlib"
 ]
-default = "deny"
 confidence-threshold = 0.8
 
 [sources]


### PR DESCRIPTION
## Summary
- ensure the `default = "deny"` setting lives directly under the `[licenses]` header in `deny.toml`
- drop the trailing comma in the allowed license list for broader TOML compatibility

## Testing
- not run (tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e21a37ca94832c9cbcf23aa15a41f1