### PR TITLE
Fix syft installation script and artifact naming in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,6 +26,7 @@ jobs:
           SYFT_TARBALL="syft_${SYFT_VERSION#v}_linux_amd64.tar.gz"
           curl -sSfL -o "$SYFT_BIN_DIR/$SYFT_TARBALL" "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/${SYFT_TARBALL}"
           tar -xzf "$SYFT_BIN_DIR/$SYFT_TARBALL" -C "$SYFT_BIN_DIR"
+          rm "$SYFT_BIN_DIR/$SYFT_TARBALL"
           chmod +x "$SYFT_BIN_DIR/syft"
       - uses: anchore/sbom-action@v0.15.7
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,13 +22,16 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$SYFT_BIN_DIR"
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | \
-            sh -s -- -b "$SYFT_BIN_DIR"
+          SYFT_VERSION="v0.102.0"
+          SYFT_TARBALL="syft_${SYFT_VERSION#v}_linux_amd64.tar.gz"
+          curl -sSfL -o "$SYFT_BIN_DIR/$SYFT_TARBALL" "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/${SYFT_TARBALL}"
+          tar -xzf "$SYFT_BIN_DIR/$SYFT_TARBALL" -C "$SYFT_BIN_DIR"
+          chmod +x "$SYFT_BIN_DIR/syft"
       - uses: anchore/sbom-action@v0.15.7
         with:
           syft-path: ${{ runner.temp }}/syft/syft
           output-file: sbom.spdx.json
       - uses: actions/upload-artifact@v4
         with:
-          name: weltgewebe-sbom-spdx-json
+          name: weltgewebe_sbom_spdx_json
           path: sbom.spdx.json


### PR DESCRIPTION
## Summary
- download syft v0.102.0 from the official GitHub release archive instead of the deprecated install script
- rename the SBOM artifact to use a GitHub Actions-compliant name

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e21ad30254832cabdf27e0c825822a