### PR TITLE
fix(ci): use github.event.schedule.cron for scheduled workflow conditions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -63,7 +63,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
        contains(github.event.pull_request.labels.*.name, 'security')) ||
-      (github.event_name == 'schedule' && github.event.schedule == '10 3 * * 0')
+      (github.event_name == 'schedule' && github.event.schedule.cron == '10 3 * * 0')
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain


### PR DESCRIPTION
## Summary
- ensure the security workflow checks scheduled cron triggers via `github.event.schedule.cron`

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e296d16acc832ca5feea77a743d98f