### PR TITLE
Fix markdown line length in peers learnings doc

### DIFF
--- a/docs/x-repo/peers-learnings.md
+++ b/docs/x-repo/peers-learnings.md
@@ -1,8 +1,11 @@
 # Kurzfassung: Übertragbare Praktiken aus HausKI, semantAH und WGX-Profil
 *(X-Repo Learnings → sofort anwendbare Leitplanken für Konsistenz & Qualität)*
 
-- **Semantische Artefakte versionieren:** Ein leichtgewichtiges Graph-Schema (z. B. `nodes.jsonl`/`edges.jsonl`) und eingebettete Cluster-Artefakte direkt im Repo halten, um Beziehungen, Themen und Backlinks portabel zu machen.
-- **Terminologie & Synonyme pflegen:** Eine gepflegte Taxonomie (z. B. `synonyms.yml`, `entities.yml`) unterstützt Suche, Filter und konsistente Begriffsnutzung.
+- **Semantische Artefakte versionieren:** Ein leichtgewichtiges Graph-Schema (z. B. `nodes.jsonl`/`edges.jsonl`)
+  und eingebettete Cluster-Artefakte direkt im Repo halten, um Beziehungen, Themen und Backlinks
+  portabel zu machen.
+- **Terminologie & Synonyme pflegen:** Eine gepflegte Taxonomie (z. B. `synonyms.yml`, `entities.yml`)
+  unterstützt Suche, Filter und konsistente Begriffsnutzung.
 - **Governance-Logik messbar machen:** Domänenregeln (**7-Tage** Verblassen, **84-Tage** RoN-Anonymisierung, Delegationsabläufe) über konkrete Metriken, Dashboards und Alerts operationalisieren. → vgl. `docs/zusammenstellung.md`
 - **WGX-Profil als Task-SSoT:** Ein zentrales Profil `.wgx/profile.yml` definiert Env-Prioritäten & Standard-Tasks (`up/lint/test/build/smoke`) und vermeidet Drift zwischen lokal & CI.
 - **Health/Readiness mit Policies koppeln:** Die bestehenden `/health/live` und `/health/ready` um Policy-Signale (Rate-Limits, Retention, Governance-Timer) ergänzen und in Runbooks verankern.


### PR DESCRIPTION
## Summary
- wrap the opening bullets in docs/x-repo/peers-learnings.md so each line stays within the 120-character limit

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3bbe07d9c832c90edabb12847b49a