### PR TITLE
Fix Markdown lint issues in x-repo learnings doc

### DIFF
--- a/docs/x-repo/peers-learnings.md
+++ b/docs/x-repo/peers-learnings.md
@@ -1,14 +1,18 @@
 # Kurzfassung: Übertragbare Praktiken aus HausKI, semantAH und WGX-Profil
-*(X-Repo Learnings → sofort anwendbare Leitplanken für Konsistenz & Qualität)*
+## X-Repo Learnings → sofort anwendbare Leitplanken für Konsistenz & Qualität
 
 - **Semantische Artefakte versionieren:** Ein leichtgewichtiges Graph-Schema (z. B. `nodes.jsonl`/`edges.jsonl`)
   und eingebettete Cluster-Artefakte direkt im Repo halten, um Beziehungen, Themen und Backlinks
   portabel zu machen.
 - **Terminologie & Synonyme pflegen:** Eine gepflegte Taxonomie (z. B. `synonyms.yml`, `entities.yml`)
   unterstützt Suche, Filter und konsistente Begriffsnutzung.
-- **Governance-Logik messbar machen:** Domänenregeln (**7-Tage** Verblassen, **84-Tage** RoN-Anonymisierung, Delegationsabläufe) über konkrete Metriken, Dashboards und Alerts operationalisieren. → vgl. `docs/zusammenstellung.md`
-- **WGX-Profil als Task-SSoT:** Ein zentrales Profil `.wgx/profile.yml` definiert Env-Prioritäten & Standard-Tasks (`up/lint/test/build/smoke`) und vermeidet Drift zwischen lokal & CI.
-- **Health/Readiness mit Policies koppeln:** Die bestehenden `/health/live` und `/health/ready` um Policy-Signale (Rate-Limits, Retention, Governance-Timer) ergänzen und in Runbooks verankern.
+- **Governance-Logik messbar machen:** Domänenregeln (**7-Tage** Verblassen, **84-Tage** RoN-Anonymisierung,
+  Delegationsabläufe) über konkrete Metriken, Dashboards und Alerts operationalisieren.
+  → vgl. `docs/zusammenstellung.md`
+- **WGX-Profil als Task-SSoT:** Ein zentrales Profil `.wgx/profile.yml` definiert Env-Prioritäten &
+  Standard-Tasks (`up/lint/test/build/smoke`) und vermeidet Drift zwischen lokal & CI.
+- **Health/Readiness mit Policies koppeln:** Die bestehenden `/health/live` und `/health/ready` um
+  Policy-Signale (Rate-Limits, Retention, Governance-Timer) ergänzen und in Runbooks verankern.
 - **UI/Produkt-Definition testbar machen:** UI-Spezifika (Map-UI, Drawer, Zeitleiste, Knotentypen) als
   Playwright-/Vitest-Szenarien automatisieren, um Regressionen früh zu erkennen.
 - **Föderierung & Archiv-Strategie festigen:** Hybrid-Indexierung durch wiederkehrende Archiv-Validierung,


### PR DESCRIPTION
## Summary
- convert the emphasized intro line into a proper heading to satisfy MD036
- wrap long bullet text to stay within the 120-character limit and appease MD013

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c1a1c0b0832ca85a5af37d66ea36