### PR TITLE
Ensure canonical links use production domain

### DIFF
--- a/apps/web/src/routes/+layout.ts
+++ b/apps/web/src/routes/+layout.ts
@@ -1,7 +1,9 @@
 import type { LayoutLoad } from './$types';
 
+const SITE_ORIGIN = 'https://weltgewebe.de';
+
 export const load: LayoutLoad = ({ url }) => {
-  const canonical = new URL(url.pathname, url.origin).toString();
+  const canonical = new URL(url.pathname, SITE_ORIGIN).toString();
 
   return {
     canonical


### PR DESCRIPTION
## Summary
- ensure canonical URLs in the SvelteKit layout always use https://weltgewebe.de

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c1a63d70832cb02137a84a40de1e