### PR TITLE
Fix markdown spacing for lint compliance

### DIFF
--- a/docs/policies/orientierung.md
+++ b/docs/policies/orientierung.md
@@ -39,8 +39,9 @@ Es beschreibt:
 | **Faden** | Verbindung zwischen Rolle ↔ Knoten (Handlung). |
 | **Garn** | Dauerhafte, verzwirnte Verbindung = Bestandsschutz. |
 
-### 3.2 Zeit und Prozesse  
-- **7-Sekunden-Rotation** → sichtbares Feedback nach Aktion.  
+### 3.2 Zeit und Prozesse
+
+- **7-Sekunden-Rotation** → sichtbares Feedback nach Aktion.
 - **7-Tage-Verblassen** → nicht verzwirnte Fäden/Knoten lösen sich auf.  
 - **7 + 7-Tage-Modell** → Anträge: Einspruch → Abstimmung.  
 - **Delegation (Liquid Democracy)** → verfällt nach 4 Wochen Inaktivität.  
@@ -110,7 +111,8 @@ Es beschreibt:
 ## 9 · Governance / Changelog-Pflicht
 
 Alle Änderungen an:
-- Datenschutz- oder Ethikparametern  
+
+- Datenschutz- oder Ethikparametern
 - Governance-Timern  
 - Sichtbarkeits-Mechaniken  
 

--- a/docs/x-repo/peers-learnings.md
+++ b/docs/x-repo/peers-learnings.md
@@ -1,4 +1,6 @@
+
 # Kurzfassung: Übertragbare Praktiken aus HausKI, semantAH und WGX-Profil
+
 ## X-Repo Learnings → sofort anwendbare Leitplanken für Konsistenz & Qualität
 
 - **Semantische Artefakte versionieren:** Ein leichtgewichtiges Graph-Schema (z. B. `nodes.jsonl`/`edges.jsonl`)


### PR DESCRIPTION
## Summary
- add missing blank lines around lists in `docs/policies/orientierung.md`
- ensure top-level headings in `docs/x-repo/peers-learnings.md` are surrounded by blank lines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c2df9bb0832ca1ca8f0ef055b148