### PR TITLE
Fix Markdown spacing for orientation policy

### DIFF
--- a/docs/policies/orientierung.md
+++ b/docs/policies/orientierung.md
@@ -10,8 +10,9 @@
 Dieses Dokument verdichtet Geist, Plan und technische Architektur des Weltgewebes zu einer verbindlichen Orientierung für
 Entwicklung, Gestaltung und Governance.  
 Es beschreibt:
-- **Was** ethisch gilt,  
-- **Wie** daraus technische und gestalterische Konsequenzen folgen,  
+
+- **Was** ethisch gilt,
+- **Wie** daraus technische und gestalterische Konsequenzen folgen,
 - **Woran** sich Teams bei Entscheidungen künftig messen lassen.
 
 ---
@@ -32,6 +33,7 @@ Es beschreibt:
 ## 3 · Systemlogik („Plan“)
 
 ### 3.1 Domänenmodell
+
 | Entität | Beschreibung |
 |----------|--------------|
 | **Rolle / Garnrolle** | Verifizierter Nutzer (Account) + Position + Privat/Öffentlich-Bereich. |


### PR DESCRIPTION
## Summary
- add the required blank line before the introductory list in `orientierung.md`
- insert a blank line after the "3.1 Domänenmodell" heading to satisfy markdown linting

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e3c84b8aac832c8188d5f5ef57e56f